### PR TITLE
Fix kafka-connect-influx-sink image name

### DIFF
--- a/charts/kafka-connect-influx-sink/values.yaml
+++ b/charts/kafka-connect-influx-sink/values.yaml
@@ -2,7 +2,7 @@
 replicaCount: 1
 
 image:
-  repository: datamountaineer/kafka-connect-influx
+  repository: datamountaineer/kafka-connect-influxdb
   tag: 1.1.0
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
datamountaineer/kafka-connect-influxdb exists

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/kafka-helm-charts/26)
<!-- Reviewable:end -->
