### PR TITLE
Influx missing CONNECTOR_TOPICS in deployment.yaml

### DIFF
--- a/charts/kafka-connect-influx-sink/templates/deployment.yaml
+++ b/charts/kafka-connect-influx-sink/templates/deployment.yaml
@@ -209,6 +209,8 @@ spec:
           value: {{ .Values.connectorClass | quote }}
         - name: CONNECTOR_TASKS_MAX
           value: {{ .Values.replicaCount | quote }}
+        - name: CONNECTOR_TOPICS
+          value: {{ .Values.topics | quote }}
         - name: CONNECTOR_CONNECT_INFLUX_KCQL
           value: {{ .Values.kcql | quote }}
         - name: CONNECTOR_CONNECT_INFLUX_DB


### PR DESCRIPTION
CONNECTOR_TOPICS environment variable missing in Influxdb deployment.yaml.

This is set in the values.yaml. Without this the sink won't run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/kafka-helm-charts/27)
<!-- Reviewable:end -->
