### PR TITLE
Split service port and resport

### DIFF
--- a/charts/lenses/templates/service.yaml
+++ b/charts/lenses/templates/service.yaml
@@ -20,7 +20,8 @@ spec:
   type: "{{ .Values.service.type }}"
   ports:
   - name: lenses
-    port: {{ .Values.restPort }}   
+    port: {{ .Values.servicePort }}   
+    target: {{ .Values.restPort }}   
   - name: http-metrics
     port: {{ .Values.monitoring.port }}
   selector:

--- a/charts/lenses/values.yaml
+++ b/charts/lenses/values.yaml
@@ -30,6 +30,7 @@ rbacEnable: true
 
 # restPort is the Lenses rest port
 restPort: 3030
+servicePort: 80
 
 # serviceAccount is the Service account to be used by Lenses to deploy apps
 serviceAccount: default


### PR DESCRIPTION
Add ability to have different resPort and servicePort in order to put a loadbalancer service as HTTP standard port

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/kafka-helm-charts/62)
<!-- Reviewable:end -->
