### PR TITLE
lenses: Add persistent volume claim for Data Policies

### DIFF
--- a/charts/lenses/Chart.yaml
+++ b/charts/lenses/Chart.yaml
@@ -1,5 +1,5 @@
 description: A chart for Lenses
 name: lenses
 version: 2.3.4
-appVersion: 2.3.1
+appVersion: 2.3.2
 icon: https://www.lenses.io/images/logos/icon_ellipse2red.png

--- a/charts/lenses/templates/cluster-role.yaml
+++ b/charts/lenses/templates/cluster-role.yaml
@@ -14,6 +14,8 @@ rules:
 - apiGroups: [""]
   resources:
     - namespaces
+    - persistentvolumes
+    - persistentvolumeclaims
   verbs: 
     - list
     - watch

--- a/charts/lenses/templates/deployment.yaml
+++ b/charts/lenses/templates/deployment.yaml
@@ -54,6 +54,11 @@ spec:
         - name: krb
           configMap:
             name: {{ include "fullname" . | quote }}
+        {{- if .Values.persistence.enabled }}
+        - name: storage
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (printf "%s-claim" (include "fullname" .)) }}
+        {{- end }}
       serviceAccountName: {{ .Values.serviceAccount }}      
       containers:
       - name: {{ .Chart.Name }}
@@ -82,6 +87,10 @@ spec:
           - name: krb
             mountPath: "/etc/processor.krb5.conf"
             subPath: "processor.krb5.conf"
+          {{- if .Values.persistence.enabled }}
+          - name: storage
+            mountPath: "/data/storage"
+          {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}     
         env:

--- a/charts/lenses/templates/volume-claim.yaml
+++ b/charts/lenses/templates/volume-claim.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+apiVersion: "v1"
+kind: "PersistentVolumeClaim"
+metadata:
+  name: {{ include "fullname" . }}-claim
+{{- if .Values.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end }}
+  labels:
+    app: {{ template "name" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    component: "lenses"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+    lenses.io/app: {{ template "name" . }}
+    lenses.io/app.type: lenses-volume-claim
+spec:
+  accessModes:
+{{ toYaml .Values.persistence.accessModes | indent 4 }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+  resources:
+    requests:
+      storage: "{{ .Values.persistence.size }}"
+{{- end -}}

--- a/charts/lenses/values.yaml
+++ b/charts/lenses/values.yaml
@@ -36,6 +36,25 @@ servicePort: 80
 # serviceAccount is the Service account to be used by Lenses to deploy apps
 serviceAccount: default
 
+# If you use Data Policies module enable a Persistent Volume to keep your data policies rule.
+persistence:
+  enabled: false
+  accessModes:
+    - ReadWriteOnce
+  size: 5Gi
+  reclaimPolicy: Retain
+  # set to true to use you own Persistent volume claim
+  existingClaim: false
+
+  ## Policies data Persistent Volume Storage Class
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+
 #service
 service:
   enabled: true


### PR DESCRIPTION
The persistent volume claim adapts based on the storage class we can
pass in the `values.yaml`.

Issue: DEVOPS-670

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/kafka-helm-charts/83)
<!-- Reviewable:end -->
