### PR TITLE
lenses: Fix static lenses port for liveness probe

### DIFF
--- a/charts/lenses/Chart.yaml
+++ b/charts/lenses/Chart.yaml
@@ -1,5 +1,5 @@
 description: A chart for Lenses
 name: lenses
-version: 2.3.4
+version: 2.3.5
 appVersion: 2.3.2
 icon: https://www.lenses.io/images/logos/icon_ellipse2red.png

--- a/charts/lenses/templates/deployment.yaml
+++ b/charts/lenses/templates/deployment.yaml
@@ -69,7 +69,7 @@ spec:
         livenessProbe:
           httpGet:
             path: /
-            port: 3030
+            port: {{ .Values.restPort }}
           initialDelaySeconds: 120
           periodSeconds: 3
         volumeMounts:

--- a/charts/lenses/values.yaml
+++ b/charts/lenses/values.yaml
@@ -42,7 +42,6 @@ persistence:
   accessModes:
     - ReadWriteOnce
   size: 5Gi
-  reclaimPolicy: Retain
   # set to true to use you own Persistent volume claim
   existingClaim: false
 


### PR DESCRIPTION
Right now we use statically 3030 for liness probe checks. We should use
the `restPort` value in case uses change the Lenses default port to a
different one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/kafka-helm-charts/84)
<!-- Reviewable:end -->
