### PR TITLE
Fix of redis image for Redis Sink helm

### DIFF
--- a/charts/kafka-connect-redis-sink/values.yaml
+++ b/charts/kafka-connect-redis-sink/values.yaml
@@ -3,7 +3,7 @@ replicaCount: 1
 # secretsRef The secret holding any passwords
 secretsRef: "__REQUIRED__"
 image:
-  repository: streamreactor/redis-sink
+  repository: streamreactor/redis
   tag: 1.2.1.7
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
The name of the image was set wrongly in values yaml because we renamed
the images.

Issue: #82

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/kafka-helm-charts/85)
<!-- Reviewable:end -->
