### PR TITLE
lenses: Remove ingress path from values

### DIFF
--- a/charts/lenses/Chart.yaml
+++ b/charts/lenses/Chart.yaml
@@ -1,5 +1,5 @@
 description: A chart for Lenses
 name: lenses
-version: 2.3.5
+version: 2.3.6
 appVersion: 2.3.2
 icon: https://www.lenses.io/images/logos/icon_ellipse2red.png

--- a/charts/lenses/templates/ingress.yaml
+++ b/charts/lenses/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
   - host: {{ .Values.ingress.host }}
     http:
       paths:
-      - path: {{if .Values.ingress.path }}{{ .Values.ingress.path }}{{else}}{{ include "fullname" . | quote }}{{end}}
+      - path: {{if .Values.ingress.path }}{{ .Values.ingress.path }}{{else}}"/"{{end}}
         backend:
           serviceName: {{ include "fullname" . | quote }}
           servicePort: {{ .Values.restPort }}

--- a/charts/lenses/values.yaml
+++ b/charts/lenses/values.yaml
@@ -81,7 +81,6 @@ ingress:
   ##
   enabled: true
   host:
-  path:
 
   # Ingress annotations
   annotations:


### PR DESCRIPTION
As right now we don't support a custom path for Lenses, we removed the
option to deploy it with this way. Soon we will add it back.

Issue:DEVOPS-756

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/kafka-helm-charts/86)
<!-- Reviewable:end -->
