### PR TITLE
Update the version for SQL Processor chart

### DIFF
--- a/charts/lenses-sql-processor-runner/Chart.yaml
+++ b/charts/lenses-sql-processor-runner/Chart.yaml
@@ -1,5 +1,5 @@
 description: A chart for Landoops Lenses SQL processor runner
 name: lenses-sql-processor-runner
-version: 2.2.0
-appVersion: 2.2.0
+version: 2.3.0
+appVersion: 2.3.1
 icon: https://www.landoop.com/images/landoop-dark.svg

--- a/charts/lenses-sql-processor-runner/values.yaml
+++ b/charts/lenses-sql-processor-runner/values.yaml
@@ -5,7 +5,7 @@
 replicaCount: 1
 image:
   repository: eu.gcr.io/lenses-container-registry/lenses-sql-processor
-  tag: 2.2
+  tag: 2.3
   pullPolicy: IfNotPresent
 
 # Resource management


### PR DESCRIPTION
This is a temporary fix, the chart will be soon deprecated and it should
be Lenses responsibility to create the Kubernetes POD and keep a single
source of truth for the POD deployment.

Issue: SRE-882

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/kafka-helm-charts/89)
<!-- Reviewable:end -->
