### PR TITLE
fix(kafka JMX): allow setting a default JMX port instead of a port per broker

### DIFF
--- a/charts/lenses/Chart.yaml
+++ b/charts/lenses/Chart.yaml
@@ -1,5 +1,5 @@
 description: A chart for Lenses
 name: lenses
-version: 2.3.7
+version: 2.3.8
 appVersion: 2.3.3
 icon: https://www.lenses.io/images/logos/icon_ellipse2red.png

--- a/charts/lenses/templates/_helper.tpl
+++ b/charts/lenses/templates/_helper.tpl
@@ -176,6 +176,9 @@ PLAINTEXT
   {{- if .Values.lenses.kafka.metrics.password}}
   "password": {{- .Values.lenses.kafka.metrics.password | quote}},
   {{- end }}
+  {{- if .Values.lenses.kafka.metrics.port}}
+  "default.port": {{- .Values.lenses.kafka.metrics.port | quote}},
+  {{- else}}
   "port": [
     {{ range $index, $element := .Values.lenses.kafka.metrics.ports }}
     {{- if not $index -}}{"id":{{$element.id}}, "port":{{$element.port}}, "host":{{$element.host}}}
@@ -184,6 +187,7 @@ PLAINTEXT
     {{- end}}
   {{- end}}
   ]
+  {{- end}}
 }
 {{- end -}}
 


### PR DESCRIPTION
for some kafka service providers such as aiven the kafka brokers sit behind a DNS record and JMX is exposed by Jolokia.
In such cases it is not possible to know the list of hosts and ports for JMX connections aparori and so the "default.port" option should be used