### PR TITLE
Aiven lenses kafka jmx settings fixes

### DIFF
--- a/charts/lenses/Chart.yaml
+++ b/charts/lenses/Chart.yaml
@@ -1,5 +1,5 @@
 description: A chart for Lenses
 name: lenses
-version: 2.3.7
+version: 2.3.8
 appVersion: 2.3.3
 icon: https://www.lenses.io/images/logos/icon_ellipse2red.png

--- a/charts/lenses/templates/_helper.tpl
+++ b/charts/lenses/templates/_helper.tpl
@@ -168,16 +168,16 @@ PLAINTEXT
 
 {{- define "kafkaMetrics" -}}
 {
-  type: {{- default "JMX" .Values.lenses.kafka.metrics.type }},
-  ssl: {{- default false .Values.lenses.kafka.metrics.ssl}},
+  type: {{ default "JMX" .Values.lenses.kafka.metrics.type | quote}},
+  ssl: {{ default false .Values.lenses.kafka.metrics.ssl}},
   {{- if .Values.lenses.kafka.metrics.username}}
-  username: {{- .Values.lenses.kafka.metrics.username }},
+  user: {{ .Values.lenses.kafka.metrics.username | quote}},
   {{- end }}
   {{- if .Values.lenses.kafka.metrics.password}}
-  password: {{- .Values.lenses.kafka.metrics.password }},
+  password: {{ .Values.lenses.kafka.metrics.password | quote}},
   {{- end }}
   {{- if .Values.lenses.kafka.metrics.port}}
-  default.port: {{- .Values.lenses.kafka.metrics.port }},
+  default.port: {{ .Values.lenses.kafka.metrics.port }},
   {{- else}}
   port: [
     {{ range $index, $element := .Values.lenses.kafka.metrics.ports }}

--- a/charts/lenses/templates/_helper.tpl
+++ b/charts/lenses/templates/_helper.tpl
@@ -168,18 +168,18 @@ PLAINTEXT
 
 {{- define "kafkaMetrics" -}}
 {
-  "type": {{- default "JMX" .Values.lenses.kafka.metrics.type | quote}},
-  "ssl": {{- default false .Values.lenses.kafka.metrics.ssl}},
+  type: {{- default "JMX" .Values.lenses.kafka.metrics.type }},
+  ssl: {{- default false .Values.lenses.kafka.metrics.ssl}},
   {{- if .Values.lenses.kafka.metrics.username}}
-  "username": {{- .Values.lenses.kafka.metrics.username | quote}},
+  username: {{- .Values.lenses.kafka.metrics.username }},
   {{- end }}
   {{- if .Values.lenses.kafka.metrics.password}}
-  "password": {{- .Values.lenses.kafka.metrics.password | quote}},
+  password: {{- .Values.lenses.kafka.metrics.password }},
   {{- end }}
   {{- if .Values.lenses.kafka.metrics.port}}
-  "default.port": {{- .Values.lenses.kafka.metrics.port | quote}},
+  default.port: {{- .Values.lenses.kafka.metrics.port }},
   {{- else}}
-  "port": [
+  port: [
     {{ range $index, $element := .Values.lenses.kafka.metrics.ports }}
     {{- if not $index -}}{"id":{{$element.id}}, "port":{{$element.port}}, "host":{{$element.host}}}
     {{- else}},

--- a/charts/lenses/templates/_helper.tpl
+++ b/charts/lenses/templates/_helper.tpl
@@ -176,6 +176,9 @@ PLAINTEXT
   {{- if .Values.lenses.kafka.metrics.password}}
   "password": {{- .Values.lenses.kafka.metrics.password | quote}},
   {{- end }}
+  {{- if .Values.lenses.kafka.metrics.port}}
+  "default.port": {{- .Values.lenses.kafka.metrics.port | quote}},
+  {{- else}}
   "port": [
     {{ range $index, $element := .Values.lenses.kafka.metrics.ports }}
     {{- if not $index -}}{"id":{{$element.id}}, "port":{{$element.port}}, "host":{{$element.host}}}
@@ -184,6 +187,7 @@ PLAINTEXT
     {{- end}}
   {{- end}}
   ]
+  {{- end}}
 }
 {{- end -}}
 


### PR DESCRIPTION

- Allow setting a default JMX port instead of a port per broker
- Dont quote the keys
- `user` instead of `username`