### PR TITLE
lenses: Fix rendering error for template and SR kerberos

### DIFF
--- a/charts/lenses/Chart.yaml
+++ b/charts/lenses/Chart.yaml
@@ -1,5 +1,5 @@
 description: A chart for Lenses
 name: lenses
-version: 2.3.12
+version: 2.3.13
 appVersion: 2.3.4
 icon: https://www.lenses.io/images/logos/icon_ellipse2red.png

--- a/charts/lenses/templates/_helper.tpl
+++ b/charts/lenses/templates/_helper.tpl
@@ -193,7 +193,7 @@ PLAINTEXT
 
 {{- define "kafkaSchemaBasicAuth" -}}
   {{- if .Values.lenses.schemaRegistries.security.enabled -}}
-    {{- if eq .Values.lenses.schemaRegistries.security.authType "USER_INFO" -}}
+    {{- if (.Values.lenses.schemaRegistries.security.authType)  and eq .Values.lenses.schemaRegistries.security.authType "USER_INFO" -}}
     {{- .Values.lenses.schemaRegistries.security.username}}:{{.Values.lenses.schemaRegistries.security.password}}
     {{- end -}}
   {{- end -}}


### PR DESCRIPTION
When auth type in SR is empty and we have enabled kerberos helm template
breaks because the condition is empty so cannot be validated to create
the deployment template correctly. Fixed the condition in the
`helper.tpl` file

Issue: SRE-1018