### PR TITLE
Fix missing empty line for `LT_PACKAGE` which breaks the conf

### DIFF
--- a/charts/lenses/Chart.yaml
+++ b/charts/lenses/Chart.yaml
@@ -1,5 +1,5 @@
 description: A chart for Lenses
 name: lenses
-version: 2.3.13
+version: 2.3.14
 appVersion: 2.3.4
 icon: https://www.lenses.io/images/logos/icon_ellipse2red.png

--- a/charts/lenses/templates/deployment.yaml
+++ b/charts/lenses/templates/deployment.yaml
@@ -371,7 +371,7 @@ spec:
         {{- range $key, $value := .Values.configOverrides }}
         - name: {{ printf "%s" $key | replace "." "_" | upper | quote }}
           value: {{ $value | quote }}
-        {{- end -}}
+        {{- end }}
 
         - name: LT_PACKAGE
           value: "helm"


### PR DESCRIPTION
The new additions about LT_ configuration broke the new line for the
`LT_PACKAGE` and was moving up to previous line as a comment, so the
value was going as a duplicate for the last configuration `LENSES_KAFKA_SETTINGS_PRODUCER_SASL_MECHANISM`

Issue: SRE-1018