### PR TITLE
redis-sink: Add support for SSL connection

### DIFF
--- a/charts/kafka-connect-redis-sink/Chart.yaml
+++ b/charts/kafka-connect-redis-sink/Chart.yaml
@@ -1,5 +1,5 @@
 
 description: A chart for kafka-connect-redis-sink
 name: kafka-connect-redis-sink
-version: 1.8
+version: 1.8.1
 appversion: 1.2.2

--- a/charts/kafka-connect-redis-sink/ci/values.yaml
+++ b/charts/kafka-connect-redis-sink/ci/values.yaml
@@ -92,3 +92,24 @@ errorPolicy: THROW
 
 # enabled Enables the output for how many records have been processed type: BOOLEAN importance: MEDIUM
 progressEnabled: true
+
+# sslEnabled enables ssl mounts
+sslEnabled: false
+
+# trustStoreType the type of the trustore
+trustStoreType:
+
+# truststorePassKey The password  key of the trust store in the secret
+trustStorePass:
+
+# trustStoreFileData is the base64 contents of the truststore file
+trustStoreFileData: |-
+
+# keyStoreType the type of the trustore
+keyStoreType:
+
+# keystorePassKey The password key of the key store in the secret
+keyStorePass:
+
+# keyStoreFileData is the base64 contents of the keystore file
+keyStoreFileData: |-

--- a/charts/kafka-connect-redis-sink/templates/deployment.yaml
+++ b/charts/kafka-connect-redis-sink/templates/deployment.yaml
@@ -28,17 +28,29 @@ spec:
         prometheus.io/port: {{ .Values.monitoring.port | quote }}
         prometheus.io/path: {{ .Values.monitoring.path | quote }}
     spec:
-      {{- if or .Values.kafka.ssl.enabled .Values.kafka.sasl.enabled }} 
+      {{- if or .Values.kafka.ssl.enabled .Values.kafka.sasl.enabled .Values.sslEnabled }}
       volumes:                
-        - name: kafka-secrets
+        {{- if .Values.sslEnabled }}
+        - name: connector-secrets
           secret:
             secretName: {{ include "fullname" . }}
+            defaultMode: 256
+            items:
+              - key: client.keystore.jks
+                path: client.keystore.jks
+              - key: client.truststore.jks
+                path: client.truststore.jks
+        {{- end }}
+        {{- if or .Values.kafka.ssl.enabled .Values.kafka.sasl.enabled}}
+        - name: kafka-secrets
+          secret:
+            secretName: {{ include "fullname" . }}-kafka-secrets
             defaultMode: 256
             items:
               {{- if .Values.kafka.ssl.enabled }}
               - key: client.keystore.jks
                 path: client.keystore.jks
-              - key: client.truststore.jks 
+              - key: client.truststore.jks
                 path: client.truststore.jks
               {{- end }}  
               {{- if .Values.kafka.sasl.enabled }}
@@ -51,8 +63,9 @@ spec:
         - name: krb
           configMap:
             name: {{ include "fullname" . | quote }}
-        {{- end }}                     
-      {{- end }}            
+        {{- end }}
+        {{- end }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -67,15 +80,21 @@ spec:
           timeoutSeconds: 5
         resources:
 {{ toYaml .Values.resources | indent 10 }}
-        {{- if or .Values.kafka.ssl.enabled .Values.kafka.sasl.enabled }} 
+        {{- if or .Values.kafka.ssl.enabled .Values.kafka.sasl.enabled .Values.sslEnabled}}
         volumeMounts: 
+          {{- if .Values.sslEnabled }}
+          - name: connector-secrets
+            mountPath: "/mnt/connector-secrets"
+          {{- end }}
+          {{- if or .Values.kafka.ssl.enabled .Values.kafka.sasl.enabled }}
           - name: kafka-secrets
             mountPath: "/mnt/secrets"
           {{- if eq .Values.kafka.sasl.mechanism "GSSAPI" }}
           - name: krb
             mountPath: "/etc/krb5.conf"
             subPath: "krb5.conf"
-          {{- end }}            
+          {{- end }}
+          {{- end }}
         {{- end }} 
         env:
         # JVM Heap Allowance
@@ -234,3 +253,25 @@ spec:
           value: {{ .Values.errorPolicy | quote }}
         - name: CONNECTOR_CONNECT_PROGRESS_ENABLED
           value: {{ .Values.progressEnabled | quote }}
+        - name: CONNECTOR_CONNECT_REDIS_SSL_ENABLED
+          value: {{ .Values.sslEnabled  | quote }}
+        {{- if .Values.sslEnabled }}
+        - name: SSL_TRUSTSTORE_TYPE_CONFIG
+          value: {{ .Values.trustStoreType}}
+        - name: SSL_TRUSTSTORE_LOCATION_CONFIG
+          value: "/mnt/connector-secrets/client.truststore.jks"
+        - name: SSL_TRUSTSTORE_PASSWORD_CONFIG
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "fullname" . }}
+              key:  "connect.redis.truststore.pass"
+        - name: SSL_KEYSTORE_TYPE_CONFIG
+          value: {{ .Values.keyStoreType}}
+        - name: SSL_KEYSTORE_LOCATION_CONFIG
+          value: "/mnt/connector-secrets/client.keystore.jks"
+        - name: SSL_KEYSTORE_PASSWORD_CONFIG
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "fullname" . }}
+              key:  "connect.redis.keystore.pass"
+        {{- end }}

--- a/charts/kafka-connect-redis-sink/templates/secret.yaml
+++ b/charts/kafka-connect-redis-sink/templates/secret.yaml
@@ -12,3 +12,11 @@ metadata:
     "helm.sh/hook": pre-install
 data:
   connect.redis.password: {{ .Values.password | b64enc }}
+  {{- if .Values.sslEnabled }}
+  connect.redis.truststore.pass: {{ .Values.trustStorePass | default "" | b64enc }}
+  connect.redis.keystore.pass: {{ .Values.keyStorePass | default "" | b64enc }}
+  client.truststore.jks: |-
+{{ .Values.trustStoreFileData  | indent 4 }}
+  client.keystore.jks: |-
+{{ .Values.keyStoreFileData  | indent 4 }}
+  {{- end }}

--- a/charts/kafka-connect-redis-sink/values.yaml
+++ b/charts/kafka-connect-redis-sink/values.yaml
@@ -123,3 +123,23 @@ errorPolicy: THROW
 # enabled Enables the output for how many records have been processed type: BOOLEAN importance: MEDIUM
 progressEnabled: true
 
+# sslEnabled enables ssl mounts
+sslEnabled: false
+
+# trustStoreType the type of the trustore
+trustStoreType:
+
+# truststorePassKey The password  key of the trust store in the secret
+trustStorePass:
+
+# trustStoreFileData is the base64 contents of the truststore file
+trustStoreFileData: |-
+
+# keyStoreType the type of the trustore
+keyStoreType:
+
+# keystorePassKey The password key of the key store in the secret
+keyStorePass:
+
+# keyStoreFileData is the base64 contents of the keystore file
+keyStoreFileData: |-


### PR DESCRIPTION
Changes for redis sink helm chart in order to support the ssl redis
connection. Truststore should be in `JCEKS`.

Issue: SRE-1018