### PR TITLE
ES5 sink support for SMT's

### DIFF
--- a/charts/kafka-connect-elastic5-sink/templates/deployment.yaml
+++ b/charts/kafka-connect-elastic5-sink/templates/deployment.yaml
@@ -231,6 +231,14 @@ spec:
         - name: CONNECTOR_CONNECT_ELASTIC_USE_HTTP
           value: {{ .Values.useHttp | quote }} 
 
+        # extra connector properties
+        {{- if .Values.transforms }}
+        {{- range $key, $value := .Values.transforms }}
+        - name: CONNECTOR_{{ $key | upper }}
+          value: {{  $value | quote }}
+        {{- end }}
+        {{- end }}
+
         # elastic client settings
         - name: CONNECTOR_CONNECT_ELASTIC_CLUSTER_NAME
           value: {{ .Values.elasticClusterName | quote }}

--- a/charts/kafka-connect-elastic5-sink/values.yaml
+++ b/charts/kafka-connect-elastic5-sink/values.yaml
@@ -98,11 +98,12 @@ topics: "__REQUIRED__"
 kcql: "__REQUIRED__"
 
 # A dictionary allowing to specify SMT's, e.g.
+# transforms:
+#   transforms: "weeklysplit"
+#   transforms_weeklysplit_type: "org.apache.kafka.connect.transforms.TimestampRouter"
+#   transforms_weeklysplit_timestamp_format: "yyyy-ww"
+#   transforms_weeklysplit_topic_format: "${topic}-${timestamp}"
 transforms:
-  transforms: "weeklysplit"
-  transforms_weeklysplit_type: "org.apache.kafka.connect.transforms.TimestampRouter"
-  transforms_weeklysplit_timestamp_format: "yyyy-ww"
-  transforms_weeklysplit_topic_format: "${topic}-${timestamp}"
 
 # batchSize How many records to process at one time. As records are pulled from Kafka it can be 100k+ which will not be feasible to throw at Elastic search at once type: INT importance: MEDIUM
 batchSize: 4000

--- a/charts/kafka-connect-elastic5-sink/values.yaml
+++ b/charts/kafka-connect-elastic5-sink/values.yaml
@@ -97,6 +97,13 @@ topics: "__REQUIRED__"
 # kcql KCQL expression describing field selection and routes. type: STRING importance: HIGH
 kcql: "__REQUIRED__"
 
+# A dictionary allowing to specify SMT's, e.g.
+transforms:
+  transforms: "weeklysplit"
+  transforms_weeklysplit_type: "org.apache.kafka.connect.transforms.TimestampRouter"
+  transforms_weeklysplit_timestamp_format: "yyyy-ww"
+  transforms_weeklysplit_topic_format: "${topic}-${timestamp}"
+
 # batchSize How many records to process at one time. As records are pulled from Kafka it can be 100k+ which will not be feasible to throw at Elastic search at once type: INT importance: MEDIUM
 batchSize: 4000
 


### PR DESCRIPTION
Hi 👋 

These changes add support for single message transforms to ES5 sink chart. All of the values are going to be translated into `CONNECTOR_` env variables, e.g. `CONNECTOR_TRANSFORMS_WEEKLYSPLIT_TYPE`.

Can you please point me in the right direction as to what changes are needed to the [dockers](https://github.com/Landoop/stream-reactor-dockers)?