### PR TITLE
fix MQTT sink/source charts

### DIFF
--- a/charts/kafka-connect-mqtt-sink/templates/deployment.yaml
+++ b/charts/kafka-connect-mqtt-sink/templates/deployment.yaml
@@ -245,7 +245,7 @@ spec:
           valueFrom:
             secretKeyRef:
               name: {{ include "fullname" . }}
-              key:  "password"
+              key:  "connect.mqtt.password"
         - name: CONNECTOR_CONNECT_MQTT_HOSTS
           value: {{ .Values.hosts | quote }} 
         - name: CONNECTOR_CONNECT_MQTT_CLIENT_ID

--- a/charts/kafka-connect-mqtt-source/templates/secret.yaml
+++ b/charts/kafka-connect-mqtt-source/templates/secret.yaml
@@ -11,7 +11,7 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install
 data:
-  connect.mqtt.password: {{ .Values.password }}
+  connect.mqtt.password: {{ .Values.password | b64enc }}
   {{- if .Values.tlsEnabled }}
   server.crt: {{ .Values.serverCrt | b64enc }}
   ca.crt: {{ .Values.caCert | b64enc }}


### PR DESCRIPTION
With this PR source and sink are in sync regarding the use of the secrets.