### PR TITLE
disable key/value converter schemas

### DIFF
--- a/charts/kafka-connect-mqtt-sink/templates/deployment.yaml
+++ b/charts/kafka-connect-mqtt-sink/templates/deployment.yaml
@@ -118,8 +118,12 @@ spec:
           value: "connect-{{ .Values.clusterName }}-statuses"
         - name: CONNECT_KEY_CONVERTER
           value: "{{ .Values.keyConverter }}"
+        - name: CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE
+          value: "{{ .Values.keyConverterSchemasEnable }}"
         - name: CONNECT_VALUE_CONVERTER
           value: "{{ .Values.valueConverter }}"
+        - name: CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE
+          value: "{{ .Values.valueConverterSchemasEnable }}"
         - name: CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL
           value: {{ include "registries" . | quote }}
         - name: CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL

--- a/charts/kafka-connect-mqtt-sink/values.yaml
+++ b/charts/kafka-connect-mqtt-sink/values.yaml
@@ -80,9 +80,11 @@ logLevel: INFO
 
 # keyConverter The key converter to/from Connects struct
 keyConverter: "io.confluent.connect.avro.AvroConverter"
+keyConverterSchemasEnable: true
 
 # valueConverter The key converter to/from Connects struct
 valueConverter: "io.confluent.connect.avro.AvroConverter"
+valueConverterSchemasEnable: true
 
 # connectorClass
 connectorClass: "com.datamountaineer.streamreactor.connect.mqtt.sink.MqttSinkConnector"

--- a/charts/kafka-connect-mqtt-source/templates/deployment.yaml
+++ b/charts/kafka-connect-mqtt-source/templates/deployment.yaml
@@ -118,8 +118,12 @@ spec:
           value: "connect-{{ .Values.clusterName }}-statuses"
         - name: CONNECT_KEY_CONVERTER
           value: "{{ .Values.keyConverter }}"
+        - name: CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE
+          value: "{{ .Values.keyConverterSchemasEnable }}"
         - name: CONNECT_VALUE_CONVERTER
           value: "{{ .Values.valueConverter }}"
+        - name: CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE
+          value: "{{ .Values.valueConverterSchemasEnable }}"
         - name: CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL
           value: {{ include "registries" . | quote }}
         - name: CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL

--- a/charts/kafka-connect-mqtt-source/values.yaml
+++ b/charts/kafka-connect-mqtt-source/values.yaml
@@ -91,9 +91,11 @@ logLevel: INFO
 
 # keyConverter The key converter to/from Connects struct
 keyConverter: "io.confluent.connect.avro.AvroConverter"
+keyConverterSchemasEnable: true
 
 # valueConverter The key converter to/from Connects struct
 valueConverter: "io.confluent.connect.avro.AvroConverter"
+valueConverterSchemasEnable: true
 
 # connectorClass class name of the connector
 connectorClass: "com.datamountaineer.streamreactor.connect.mqtt.source.MqttSourceConnector"


### PR DESCRIPTION
this PR adds options to disable key/value converter schemas for source and sinks, which are enabled by default