### PR TITLE
add option to MQTT sink to enable retained messages, disabled by default

### DIFF
--- a/charts/kafka-connect-mqtt-sink/templates/deployment.yaml
+++ b/charts/kafka-connect-mqtt-sink/templates/deployment.yaml
@@ -258,6 +258,8 @@ spec:
           value: {{ .Values.pollingTimeout | quote }}
         - name: CONNECTOR_CONNECT_MQTT_SERVICE_QUALITY
           value: {{ .Values.serviceQuality | quote }}
+        - name: CONNECTOR_CONNECT_MQTT_RETAINED_MESSAGES
+          value: {{ .Values.retainedMessages | quote }}
         - name: CONNECTOR_CONNECT_MQTT_KEEP_ALIVE
           value: {{ .Values.keepAlive | quote }}
         - name: CONNECTOR_CONNECT_MQTT_RETRY_INTERVAL

--- a/charts/kafka-connect-mqtt-sink/values.yaml
+++ b/charts/kafka-connect-mqtt-sink/values.yaml
@@ -121,6 +121,9 @@ keepAlive: 5000
 # serviceQuality Specifies the Mqtt quality of service type: INT importance: MEDIUM
 serviceQuality: "__REQUIRED__"
 
+# retainedMessages Specifies that the broker should store last retained message type: BOOLEAN importance: MEDIUM
+retainedMessages: false
+
 # sslEnabled enabled tls
 tlsEnabled: false
 


### PR DESCRIPTION
this PR adds the option to specify retained messages on MQTT Sink topic. 

relates to: https://github.com/Landoop/stream-reactor/pull/623